### PR TITLE
chore: only CLAIMER_ROLE can addRewardsToUnderlying

### DIFF
--- a/contracts/core/EigenLayerRETHVault.sol
+++ b/contracts/core/EigenLayerRETHVault.sol
@@ -19,6 +19,8 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 /// @custom:oz-upgrades-unsafe-allow constructor state-variable-immutable
 contract EigenLayerRETHVault is Initializable, RocketPoolVault {
 
+    bytes32 public constant CLAIMER_ROLE = keccak256("CLAIMER_ROLE");
+
     using Swap for ISwapRouter;
     using SafeERC20 for IERC20;
 
@@ -361,7 +363,7 @@ contract EigenLayerRETHVault is Initializable, RocketPoolVault {
         uint256[] calldata amounts,
         uint256[] calldata amountsOutMin,
         uint24[] calldata fees
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    ) external onlyRole(CLAIMER_ROLE) {
         require(
             tokens.length == amounts.length
             && tokens.length == fees.length

--- a/test/EigenLayerRETHVault.test.ts
+++ b/test/EigenLayerRETHVault.test.ts
@@ -223,7 +223,7 @@ describe("EigenLayerRETHVault", () => {
 		const amountIn = ethers.parseEther("0.1");
 		const feeTier = 3000; // typical Uniswap V3 fee tier
 
-		it("Should fail for non admin", async () => {
+		it("Should fail for non claim role", async () => {
 			const { eigenLayerUniswap, user1 } = await loadFixture(deployFixtures);
 			await expect(eigenLayerUniswap.connect(user1).addRewardsToUnderlying([wethAddress], [], [amountIn], [0], [feeTier])).to.be.revertedWithCustomError(
 				eigenLayerUniswap,
@@ -232,8 +232,9 @@ describe("EigenLayerRETHVault", () => {
 		});
 
 		it("Should fail for invalid inputs", async () => {
-			const { eigenLayerUniswap } = await loadFixture(deployFixtures);
-			await expect(eigenLayerUniswap.addRewardsToUnderlying([wethAddress], [], [amountIn], [0], [])).to.be.revertedWith("addRewardsToUnderlying: Invalid input");
+			const { eigenLayerUniswap, user1 } = await loadFixture(deployFixtures);
+			await eigenLayerUniswap.grantRole("0x11a8cb5a02bd6c42679835e867ef2118ba78f088f8300511420c6603c21d9c78", user1);
+			await expect(eigenLayerUniswap.connect(user1).addRewardsToUnderlying([wethAddress], [], [amountIn], [0], [])).to.be.revertedWith("addRewardsToUnderlying: Invalid input");
 		});
 
 		it("should successfully swap WETH rewards into the underlying token", async () => {
@@ -262,6 +263,7 @@ describe("EigenLayerRETHVault", () => {
 			const swapPath = ethers.solidityPacked(["address", "uint24", "address"], [wethAddress, feeTier, rETHAddress]);
 
 			// --- Capture the event and verify the underlying token’s balance ---
+			await eigenLayerUniswap.grantRole("0x11a8cb5a02bd6c42679835e867ef2118ba78f088f8300511420c6603c21d9c78", owner);
 			const tx = await eigenLayerUniswap.connect(owner).addRewardsToUnderlying([wethAddress], [swapPath], [amountIn], [0], [feeTier]);
 			let args: any[];
 			const receipt = await tx.wait();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new role-based access control for managing reward additions, allowing only users with a specific claim role to perform this action.

- **Tests**
  - Updated tests to reflect the new claim role requirement, ensuring accurate validation of permissions and input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->